### PR TITLE
fix: Refactor event target retrieval in multiple plugins to use compo…

### DIFF
--- a/plugin-render-antd/src/index.ts
+++ b/plugin-render-antd/src/index.ts
@@ -9,7 +9,7 @@ import type { VxeUIPluginObject, VxeGlobalInterceptorHandles } from 'vxe-pc-ui'
  */
 function getEventTargetNode (evnt: any, container: HTMLElement, className: string) {
   let targetElem
-  let target = evnt.target
+  let target = evnt.composedPath?.()?.[0] || evnt.target
   while (target && target.nodeType && target !== document) {
     if (className && target.className && target.className.split && target.className.split(' ').indexOf(className) > -1) {
       targetElem = target

--- a/plugin-render-element/src/form/index.ts
+++ b/plugin-render-element/src/form/index.ts
@@ -182,7 +182,7 @@ export function defineFormRender (VxeUI: VxeUIExport) {
  */
   function getEventTargetNode (evnt: any, container: HTMLElement, className: string) {
     let targetElem
-    let target = evnt.target
+    let target = evnt.composedPath?.()?.[0] || evnt.target
     while (target && target.nodeType && target !== document) {
       if (className && target.className && target.className.split && target.className.split(' ').indexOf(className) > -1) {
         targetElem = target

--- a/plugin-render-element/src/index.ts
+++ b/plugin-render-element/src/index.ts
@@ -12,7 +12,7 @@ let ElementPlus: any
  */
 function getEventTargetNode (evnt: any, container: HTMLElement, className: string) {
   let targetElem
-  let target = evnt.target
+  let target = evnt.composedPath?.()?.[0] || evnt.target
   while (target && target.nodeType && target !== document) {
     if (className && target.className && target.className.split && target.className.split(' ').indexOf(className) > -1) {
       targetElem = target

--- a/plugin-render-iview/src/index.ts
+++ b/plugin-render-iview/src/index.ts
@@ -5,7 +5,7 @@ import type { VxeUIPluginObject, VxeGlobalInterceptorHandles } from 'vxe-pc-ui'
  */
 function getEventTargetNode (evnt: any, container: HTMLElement, className: string) {
   let targetElem
-  let target = evnt.target
+  let target = evnt.composedPath?.()?.[0] || evnt.target
   while (target && target.nodeType && target !== document) {
     if (className && target.className && target.className.split && target.className.split(' ').indexOf(className) > -1) {
       targetElem = target

--- a/plugin-render-naive/src/index.ts
+++ b/plugin-render-naive/src/index.ts
@@ -5,7 +5,7 @@ import type { VxeUIPluginObject, VxeGlobalInterceptorHandles } from 'vxe-pc-ui'
  */
 function getEventTargetNode (evnt: any, container: HTMLElement, className: string) {
   let targetElem
-  let target = evnt.target
+  let target = evnt.composedPath?.()?.[0] || evnt.target
   while (target && target.nodeType && target !== document) {
     if (className && target.className && target.className.split && target.className.split(' ').indexOf(className) > -1) {
       targetElem = target


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/178dd76b-dd5c-431b-8c4c-9aca6398cb41)
如上图，表格在无界子应用中使用时，event.target 始终指向根 Shadow DOM，无法获取真的 event-target